### PR TITLE
Can disable build bumping for a testflight deploys via config

### DIFF
--- a/lib/config/example.yml
+++ b/lib/config/example.yml
@@ -31,3 +31,4 @@ distributions:
      token: somethingthatlookslikeyourapitoken
      default_list: Foo People
      configuration: Release
+     increments_build_number: false # use to decide whether or not to increment and commit new build number (default true)

--- a/lib/tasks/testflight.rake
+++ b/lib/tasks/testflight.rake
@@ -42,6 +42,7 @@ namespace :testflight do
       @team_token = info['token']
       @distribution_list = info['default_list']
       @configuration = info['configuration']
+      @bumps_build_number = info['increments_build_number'].nil? ? true : info['increments_build_number']
       @configured = true
       Rake::Task["testflight:deploy"].invoke
     end
@@ -55,7 +56,11 @@ namespace :testflight do
     build_dir = @thrust.build_dir_for(build_configuration)
     target = @thrust.config['app_name']
 
-    Rake::Task["bump:build"].invoke
+    if (@bumps_build_number)
+      Rake::Task["bump:build"].invoke
+    else
+      @thrust.check_for_clean_working_tree
+    end
 
     STDERR.puts "Cleaning..."
     @thrust.xcodeclean(build_configuration, 'iphoneos')

--- a/lib/thrust_config.rb
+++ b/lib/thrust_config.rb
@@ -142,12 +142,20 @@ class ThrustConfig
       STDERR.puts 'WARNING NOT CHECKING FOR CLEAN WORKING DIRECTORY'
       block.call
     else
-      STDERR.puts 'Checking for clean working tree...'
-      system_or_exit 'git diff-index --quiet HEAD'
+      check_for_clean_working_tree
       STDERR.puts 'Checking that the master branch is up to date...'
       system_or_exit 'git fetch && git diff --quiet HEAD origin/master'
       block.call
       system_or_exit "git commit -am \"#{message}\" && git push origin head"
+    end
+  end
+
+  def check_for_clean_working_tree
+    if ENV['IGNORE_GIT']
+      STDERR.puts 'WARNING NOT CHECKING FOR CLEAN WORKING DIRECTORY'
+    else
+      STDERR.puts 'Checking for clean working tree...'
+      system_or_exit 'git diff-index --quiet HEAD'
     end
   end
 end


### PR DESCRIPTION
We still check that the repo is clean but do not require it to be the head of origin/master as we don't need to commit anything.
[completes #55131540]
