### PR TITLE
Smarter clean task

### DIFF
--- a/lib/config/example.yml
+++ b/lib/config/example.yml
@@ -4,12 +4,6 @@ project_name: My Great Project
 app_name: My Great Project
 identity: iOS Signing Identity
 
-# configurations to clean.
-configurations:
-  - AdHoc
-  - Debug
-  - Release
-
 sim_binary: 'Specs/bin/ios-sim' # or 'Specs/bin/waxim'
 spec_targets:
   specs:

--- a/lib/tasks/cedar.rake
+++ b/lib/tasks/cedar.rake
@@ -39,7 +39,7 @@ end
 
 desc 'Clean all targets'
 task :clean do
-  (@thrust.config[:configurations] || %w{AdHoc Debug Release}).each do |config|
+  @thrust.xcode_build_configurations.each do |config|
     @thrust.xcode_clean(config)
   end
 end

--- a/lib/thrust_config.rb
+++ b/lib/thrust_config.rb
@@ -57,6 +57,16 @@ class ThrustConfig
     run_xcode('clean', build_configuration)
   end
 
+  def xcode_build_configurations
+    output = `xcodebuild -project #{config['project_name']}.xcodeproj -list`
+    match = /Build Configurations:(.+?)\n\n/m.match(output)
+    if match
+      match[1].strip.split("\n").map { |line| line.strip }
+    else
+      []
+    end
+  end
+
   def xcode_package(build_configuration)
     build_dir = build_dir_for(build_configuration)
     app_name = get_app_name_from(build_dir)


### PR DESCRIPTION
Use xcodebuild -list to get all the build configurations to clean instead of assuming AdHoc, Debug & Release (for projects that don't have AdHoc).
