### PR TITLE
Don't exit(0) when specs pass.

### DIFF
--- a/lib/thrust_config.rb
+++ b/lib/thrust_config.rb
@@ -175,8 +175,6 @@ class ThrustConfig
 
     if !result.include?("Finished") || result.include?("FAILURE") || result.include?("EXCEPTION")
       exit(1)
-    else
-      exit(0)
     end
   end
 


### PR DESCRIPTION
This allows multiple specs spec targets to run together (e.g. - CI task).
