### PR TITLE
add option for including timestamp in ios build numbers

### DIFF
--- a/lib/thrust/ios/agv_tool.rb
+++ b/lib/thrust/ios/agv_tool.rb
@@ -6,8 +6,8 @@ module Thrust
         @git = git
       end
 
-      def change_build_number(build_number)
-        @thrust_executor.system_or_exit "agvtool new-version -all '#{build_number}'"
+      def change_build_number(build_number:, timestamp: nil)
+        @thrust_executor.system_or_exit "agvtool new-version -all '#{timestamp ? timestamp + '-' : ''}#{build_number}'"
         @git.checkout_file('*.xcodeproj')
       end
     end

--- a/lib/thrust/ios/deploy.rb
+++ b/lib/thrust/ios/deploy.rb
@@ -16,9 +16,11 @@ module Thrust
         @git.ensure_clean
 
         if (@deployment_config.versioning_method == 'commits')
-          @agv_tool.change_build_number(@git.commit_count)
+          @agv_tool.change_build_number(build_number: @git.commit_count)
+        elsif (@deployment_config.versioning_method == 'timestamp-sha')
+          @agv_tool.change_build_number(timestamp: Time.now.utc.strftime('%y%m%d%H%M'), build_number: @git.current_commit)
         else
-          @agv_tool.change_build_number(@git.current_commit)
+          @agv_tool.change_build_number(build_number: @git.current_commit)
         end
 
         app_name = @thrust_config.app_config.app_name

--- a/spec/lib/thrust/ios/agv_tool_spec.rb
+++ b/spec/lib/thrust/ios/agv_tool_spec.rb
@@ -11,19 +11,44 @@ describe Thrust::IOS::AgvTool do
   end
 
   describe '#change_build_number' do
-    before do
-      subject.change_build_number(1000)
+    context 'without a timestamp argument' do
+      before do
+        subject.change_build_number(build_number: 1000)
+      end
+
+      it 'instructs agvtool to change the version' do
+        expect(thrust_executor.system_or_exit_history.last)
+        .to eq(
+                {
+                    cmd: 'agvtool new-version -all \'1000\'',
+                    output_file: nil
+                }
+            )
+      end
+
+      it 'resets the .xcodeproj files via git' do
+        expect(git).to have_received(:checkout_file).with('*.xcodeproj')
+      end
     end
 
-    it 'instructs agvtool to change the version' do
-      expect(thrust_executor.system_or_exit_history.last).to eq({
-        cmd: 'agvtool new-version -all \'1000\'',
-        output_file: nil
-      })
-    end
+    context 'with a timestamp argument' do
+      before do
+        subject.change_build_number(build_number: 1000, timestamp: '1402021234')
+      end
 
-    it 'resets the .xcodeproj files via git' do
-      expect(git).to have_received(:checkout_file).with('*.xcodeproj')
+      it 'instructs agvtool to change the version' do
+        expect(thrust_executor.system_or_exit_history.last)
+        .to eq(
+                {
+                    cmd: 'agvtool new-version -all \'1402021234-1000\'',
+                    output_file: nil
+                }
+            )
+      end
+
+      it 'resets the .xcodeproj files via git' do
+        expect(git).to have_received(:checkout_file).with('*.xcodeproj')
+      end
     end
   end
 end

--- a/spec/lib/thrust/ios/deploy_spec.rb
+++ b/spec/lib/thrust/ios/deploy_spec.rb
@@ -61,14 +61,34 @@ describe Thrust::IOS::Deploy do
       end
 
       it "updates the version number to the number of commits on the current branch" do
-        agv_tool.should_receive(:change_build_number).with(149)
+        agv_tool.should_receive(:change_build_number).with(build_number: 149)
+        deploy.run
+      end
+    end
+
+    context "when versioning method is set to timestamp-sha" do
+      let(:distribution_config) do
+        Thrust::DeploymentTarget.new(
+            'notify' => 'true',
+            'distribution_list' => 'devs',
+            'ios_build_configuration' => 'configuration',
+            'ios_provisioning_search_query' => 'Provisioning Profile query',
+            'note_generation_method' => 'autotag',
+            'versioning_method' => 'timestamp-sha'
+        )
+      end
+
+      it "updates the version number to the current git SHA and a timestamp in UTC" do
+        mocked_time = Time.parse("Thu Mar 29 22:33:20 PST 2014")
+        Time.stub(:now).and_return(mocked_time)
+        agv_tool.should_receive(:change_build_number).with(timestamp: '1403300633', build_number: '31758012490')
         deploy.run
       end
     end
 
     context "when versioning method is set to anything else" do
       it 'updates the version number to the current git SHA' do
-        agv_tool.should_receive(:change_build_number).with('31758012490')
+        agv_tool.should_receive(:change_build_number).with(build_number: '31758012490')
         deploy.run
       end
     end


### PR DESCRIPTION
We elected not to alter the behavior for Android as TestFlight no longer supports that platform.
