### PR TITLE
Kill the simulator before running iOS spec suites

### DIFF
--- a/lib/thrust/ios/x_code_tools.rb
+++ b/lib/thrust/ios/x_code_tools.rb
@@ -55,14 +55,14 @@ module Thrust
         @thrust_executor.check_command_for_failure(cmd)
       end
 
-      private
-
       def kill_simulator
         @out.puts('Killing simulator...')
         @thrust_executor.system %q[killall -m -KILL "gdb"]
         @thrust_executor.system %q[killall -m -KILL "otest"]
         @thrust_executor.system %q[killall -m -KILL "iPhone Simulator"]
       end
+
+      private
 
       def provision_path(provision_search_query)
         provision_search_path = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/")

--- a/lib/thrust/tasks/ios_specs.rb
+++ b/lib/thrust/tasks/ios_specs.rb
@@ -26,6 +26,7 @@ module Thrust
         xcode_tools.build_scheme_or_target(scheme || target, build_sdk)
 
         if type == 'app'
+          xcode_tools.kill_simulator
           @cedar.run(build_configuration, target, runtime_sdk, build_sdk, target_info.device, thrust.build_dir, thrust.app_config.ios_sim_binary)
         else
           xcode_tools.test(target || scheme, build_configuration, runtime_sdk, thrust.build_dir)

--- a/spec/lib/thrust/tasks/ios_specs_spec.rb
+++ b/spec/lib/thrust/tasks/ios_specs_spec.rb
@@ -42,6 +42,7 @@ describe Thrust::Tasks::IOSSpecs do
         xcode_tools_provider.stub(:instance).with(out, 'build-configuration', 'build-dir', tools_options).and_return(xcode_tools)
 
         expect(xcode_tools).to receive(:build_scheme_or_target).with('some-scheme', 'build-sdk')
+        expect(xcode_tools).to receive(:kill_simulator)
         expect(cedar).to receive(:run).with('build-configuration', 'some-target', 'runtime-sdk', 'build-sdk', 'device', 'build-dir', 'ios-sim').and_return(:success)
 
         result = subject.run(thrust, target_info, args)


### PR DESCRIPTION
This is to alleviate flakiness in launching the simulator when running specs.  Right now, our specs often fail because Springboard fails to launch.  We think that killing the simulator before test runs will fix this since that's how we fix the problem when running the specs in XCode.
