### PR TITLE
Add synx task to iOS projects

### DIFF
--- a/lib/tasks/synx.rake
+++ b/lib/tasks/synx.rake
@@ -1,0 +1,10 @@
+require_relative '../thrust'
+
+@thrust = Thrust::Config.make(Dir.getwd, File.join(Dir.getwd, 'thrust.yml'))
+
+if !File.exists?('AndroidManifest.xml')
+  desc 'Sync directory structure with Xcode groups'
+  task :synx do
+    Thrust::IOS::Synx.new(@thrust.app_config.project_name).run
+  end
+end

--- a/lib/thrust.rb
+++ b/lib/thrust.rb
@@ -13,6 +13,7 @@ require 'thrust/ios/agv_tool'
 require 'thrust/ios/cedar'
 require 'thrust/ios/deploy'
 require 'thrust/ios/deploy_provider'
+require 'thrust/ios/synx'
 require 'thrust/ios/x_code_tools'
 require 'thrust/ios/x_code_tools_provider'
 

--- a/lib/thrust/ios/synx.rb
+++ b/lib/thrust/ios/synx.rb
@@ -1,0 +1,15 @@
+module Thrust
+  module IOS
+    class Synx
+      def initialize(project_name, thrust_executor = Thrust::Executor.new)
+        @project_name = project_name
+        @thrust_executor = thrust_executor
+        raise "project_name required" unless !@project_name.nil?
+      end
+
+      def run
+        @thrust_executor.system_or_exit "synx #{@project_name}.xcodeproj"
+      end
+    end
+  end
+end

--- a/lib/thrust/tasks.rb
+++ b/lib/thrust/tasks.rb
@@ -1,4 +1,5 @@
 load File.expand_path('../../tasks/cedar.rake', __FILE__) unless File.exists?('AndroidManifest.xml')
 load File.expand_path('../../tasks/autotag.rake', __FILE__)
+load File.expand_path('../../tasks/synx.rake', __FILE__) unless File.exists?('AndroidManifest.xml')
 load File.expand_path('../../tasks/testflight.rake', __FILE__)
 load File.expand_path('../../tasks/version.rake', __FILE__)

--- a/spec/lib/thrust/tasks/synx_spec.rb
+++ b/spec/lib/thrust/tasks/synx_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Thrust::IOS::Synx do
+  describe '.initialize' do
+    it 'requires either a project_name' do
+      expect { Thrust::IOS::Synx.new }.to raise_error
+    end
+  end
+
+  describe '#run' do
+    it "runs synx on the project" do
+      thrust_executor = Thrust::FakeExecutor.new
+      allow(thrust_executor).to receive(:system_or_exit)
+      Thrust::IOS::Synx.new("MyProject", thrust_executor).run
+      expect(thrust_executor).to have_received(:system_or_exit).with("synx MyProject.xcodeproj")
+    end
+  end
+end

--- a/thrust.gemspec
+++ b/thrust.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'colorize', '~> 0.6'
   s.add_runtime_dependency 'auto_tagger', '~> 0.2'
   s.add_runtime_dependency 'rake', '~> 10.1'
+  s.add_runtime_dependency 'synx', '~> 0.0.4'
   s.add_development_dependency 'fakefs', '~> 0.5'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'timecop'


### PR DESCRIPTION
- synx reorganizes the project file structure to mimic Xcode groups
  - https://github.com/venmo/synx
- requires project_name to be set
