### PR TITLE
Adding clean step to xcodebuild invocation

### DIFF
--- a/lib/thrust/ios/x_code_tools.rb
+++ b/lib/thrust/ios/x_code_tools.rb
@@ -36,7 +36,7 @@ module Thrust
 
       def build_scheme_or_target(scheme_or_target, build_sdk, architecture=nil)
         @out.puts "Building..."
-        run_xcode('build', build_sdk, scheme_or_target, architecture)
+        run_xcode(build_sdk, scheme_or_target, architecture)
       end
 
       def test(scheme, build_configuration, runtime_sdk, build_dir)
@@ -97,7 +97,7 @@ module Thrust
         end
       end
 
-      def run_xcode(build_command, sdk = nil, scheme_or_target = nil, architecture = nil)
+      def run_xcode(sdk = nil, scheme_or_target = nil, architecture = nil)
         architecture_flag = architecture ? "-arch #{architecture}" : nil
         target_flag = @workspace_name ? "-scheme \"#{scheme_or_target}\"" : "-target \"#{scheme_or_target}\""
         sdk_flag = sdk ? "-sdk #{sdk}" : nil
@@ -112,13 +112,13 @@ module Thrust
           target_flag,
           "-configuration #{@build_configuration}",
           sdk_flag,
-          "#{build_command}",
+          "clean build",
           "SYMROOT=#{@build_directory.inspect}",
           configuration_build_dir_option,
           '2>&1',
           "| grep -v 'backing file'"
         ].compact.join(' ')
-        output_file = output_file("#{@build_configuration}-#{build_command}")
+        output_file = output_file("#{@build_configuration}-build")
         begin
           @thrust_executor.system_or_exit(command, output_file)
         rescue Thrust::Executor::CommandFailed => e

--- a/spec/lib/thrust/ios/x_code_tools_spec.rb
+++ b/spec/lib/thrust/ios/x_code_tools_spec.rb
@@ -63,7 +63,7 @@ describe Thrust::IOS::XCodeTools do
         context 'when the build_sdk is not macosx' do
           it 'calls xcodebuild with the build command' do
             expect(thrust_executor.system_or_exit_history.last).to eq({
-              cmd: 'set -o pipefail && xcodebuild -project AwesomeProject.xcodeproj -arch i386 -target "AppTarget" -configuration Release -sdk iphoneos build SYMROOT="build" CONFIGURATION_BUILD_DIR="build/Release-iphoneos" 2>&1 | grep -v \'backing file\'',
+              cmd: 'set -o pipefail && xcodebuild -project AwesomeProject.xcodeproj -arch i386 -target "AppTarget" -configuration Release -sdk iphoneos clean build SYMROOT="build" CONFIGURATION_BUILD_DIR="build/Release-iphoneos" 2>&1 | grep -v \'backing file\'',
               output_file: 'build/Release-build.output'
             })
           end
@@ -74,7 +74,7 @@ describe Thrust::IOS::XCodeTools do
 
           it 'does not include CONFIGURATION_BUILD_DIR' do
             expect(thrust_executor.system_or_exit_history.last).to eq({
-              cmd: 'set -o pipefail && xcodebuild -project AwesomeProject.xcodeproj -arch i386 -target "AppTarget" -configuration Release -sdk macosx build SYMROOT="build" 2>&1 | grep -v \'backing file\'',
+              cmd: 'set -o pipefail && xcodebuild -project AwesomeProject.xcodeproj -arch i386 -target "AppTarget" -configuration Release -sdk macosx clean build SYMROOT="build" 2>&1 | grep -v \'backing file\'',
               output_file: 'build/Release-build.output'
             })
           end
@@ -108,7 +108,7 @@ describe Thrust::IOS::XCodeTools do
         subject.build_scheme_or_target(target, build_sdk, arch)
 
         expect(thrust_executor.system_or_exit_history.last).to eq({
-                                                                    cmd: 'set -o pipefail && xcodebuild -workspace AwesomeWorkspace.xcworkspace -arch i386 -scheme "AppTarget" -configuration Release -sdk iphoneos build SYMROOT="build" CONFIGURATION_BUILD_DIR="build/Release-iphoneos" 2>&1 | grep -v \'backing file\'',
+                                                                    cmd: 'set -o pipefail && xcodebuild -workspace AwesomeWorkspace.xcworkspace -arch i386 -scheme "AppTarget" -configuration Release -sdk iphoneos clean build SYMROOT="build" CONFIGURATION_BUILD_DIR="build/Release-iphoneos" 2>&1 | grep -v \'backing file\'',
                                                                     output_file: 'build/Release-build.output'
                                                                   })
       end


### PR DESCRIPTION
 This fixes a bug in which nibs were not being consistently included in build product
