### PR TITLE
A few improvements for Xcode 6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ If you had **Thrust** previously installed as a submodule, we recommend that you
 
 # Changelog
 
+## Version 0.5
+
+* Removes support for waxsim
+* Unifies configuration of Cedar Spec Suites and Cedar/iOS/OSX test bundles in thrust.yml (breaking configuration changes) 
+* Fixes hardcoded bundle test destination which was broken in Xcode 6+
+* Allows bundles to be built for architectures specified in Xcode project (removes hardcoded ARCHS flag)
+* Adds support for specifying an alternate path to ios-sim
+ 
 ## Version 0.4
 
 * Added support for Xcode 6 and ios-sim 3.x.  You should now specify `device_type_id` in your `thrust.yml` instead of `device`.
@@ -97,12 +105,12 @@ If you had **Thrust** previously installed as a submodule, we recommend that you
 ## Example thrust.yml for iOS
 
 ```yaml
-thrust_version: 0.4
+thrust_version: 0.5
 project_name: My Great Project # do not use if building with an xcode workspace
 # workspace_name: My Workspace # use if building with an xcode workspace
 app_name: My Great App
 ios_distribution_certificate: 'Name of Distribution Signing Certificate'
-ios_sim_binary: 'ios-sim' # or wax-sim. iOS only.
+ios_sim_path: '/path/to/ios-sim' # Optional. Use to prefer a specific ios-sim binary (e.g. within project directory) over a system-installed version (homebrew)
 
 testflight:
   api_token: 'testflight api token' # To find your App Token, follow the instructions at: http://help.testflightapp.com/customer/portal/articles/829956-what-does-the-api-token-do-
@@ -128,16 +136,14 @@ ios_spec_targets:
     type: app # Spec target type: app or bundle. Optional, defaults to app.
     build_configuration: Debug # name of the build configuration
     build_sdk: iphonesimulator7.0 # SDK used to build the target. Optional, defaults to latest iphonesimulator.
-    runtime_sdk: 7.0 # SDK used to run the target. Not optional.
-#    device: ipad # Device to run the specs on. Deprecated in ios-sim 3.0+, use device_type_id instead.
-    device_type_id: com.apple.CoreSimulator.SimDeviceType.iPad-Retina, 7.0 # required if using ios-sim 3.0
+    device_name: iPhone-4s # device name as suggested by ios-sim showdevicetypes
+    os_version: 7.1 # OS version to run. Defaults to latest available version.
 
   integration:
     target: IntegrationSpecs
 #    scheme: IntegrationSpecs (My Great App) # use in addition to target when you want to use a scheme (necessary if you are building with an xcode workspace)
     build_configuration: Release
     build_sdk: macosx
-    runtime_sdk: macosx
 ```
 
 

--- a/lib/config/ios_example.yml
+++ b/lib/config/ios_example.yml
@@ -1,10 +1,10 @@
-thrust_version: 0.4
+thrust_version: 0.5
 project_name: My Great Project # do not use if building with an xcode workspace
 # workspace_name: My Workspace # use if building with an xcode workspace
 # path_to_xcodeproj: 'App/MyApp.xcodeproj' # use if xcodeproj is not in the same directory as this yaml file. Optional.
 app_name: My Great App
 ios_distribution_certificate: 'Name of Distribution Signing Certificate'
-ios_sim_binary: 'ios-sim' # or wax-sim. iOS only.
+#ios_sim_path: '/path/to/ios-sim' # Optional. Use to prefer a specific ios-sim binary (e.g. within project directory) over a system-installed version (homebrew)
 
 testflight:
   api_token: 'testflight api token' # To find your App Token, follow the instructions at: http://help.testflightapp.com/customer/portal/articles/829956-what-does-the-api-token-do-
@@ -31,13 +31,11 @@ ios_spec_targets:
     type: app # Spec target type: app or bundle. Optional, defaults to app.
     build_configuration: Debug # name of the build configuration
     build_sdk: iphonesimulator7.0 # SDK used to build the target. Optional, defaults to latest iphonesimulator.
-    runtime_sdk: 7.0 # SDK used to run the target. Not optional.
-#    device: ipad # Device to run the specs on. Deprecated in ios-sim 3.0+, use device_type_id instead.
-    device_type_id: com.apple.CoreSimulator.SimDeviceType.iPad-Retina, 7.0 # required if using ios-sim 3.0
+    device_name: iPhone-4s # device name as suggested by ios-sim showdevicetypes
+    os_version: 7.1 # OS version to run. Defaults to latest available version.
 
   integration:
     target: IntegrationSpecs
 #    scheme: IntegrationSpecs (My Great App) # use in addition to target when you want to use a scheme (necessary if you are building with an xcode workspace)
     build_configuration: Release
     build_sdk: macosx
-    runtime_sdk: macosx

--- a/lib/tasks/cedar.rake
+++ b/lib/tasks/cedar.rake
@@ -27,7 +27,7 @@ task :clean_build => :clean
 
 @thrust.app_config.ios_spec_targets.each do |target_name, target_info|
   desc target_info.scheme ? "Run the #{target_info.scheme} scheme" : "Run the #{target_info.target} target"
-  task target_name, :runtime_sdk do |_, args|
+  task target_name, :os_version do |_, args|
     exit(1) unless Thrust::Tasks::IOSSpecs.new.run(@thrust, target_info, args)
   end
 end

--- a/lib/thrust/app_config.rb
+++ b/lib/thrust/app_config.rb
@@ -7,7 +7,7 @@ module Thrust
     attr_reader :app_name,
                 :deployment_targets,
                 :ios_distribution_certificate,
-                :ios_sim_binary,
+                :ios_sim_path,
                 :ios_spec_targets,
                 :project_name,
                 :testflight,
@@ -19,7 +19,7 @@ module Thrust
       @app_name = attributes['app_name']
       @deployment_targets = generate_deployment_targets(attributes['deployment_targets'])
       @ios_distribution_certificate = attributes['ios_distribution_certificate']
-      @ios_sim_binary = attributes['ios_sim_binary']
+      @ios_sim_path = attributes['ios_sim_path']
       @ios_spec_targets = generate_ios_spec_targets(attributes['ios_spec_targets'])
       @project_name = attributes['project_name']
       @testflight = generate_testflight_credentials(attributes['testflight'])

--- a/lib/thrust/config.rb
+++ b/lib/thrust/config.rb
@@ -6,7 +6,7 @@ module Thrust
   class Config
     attr_reader :project_root, :app_config, :build_dir
 
-    THRUST_VERSION = '0.4'
+    THRUST_VERSION = '0.5'
     THRUST_ROOT = File.expand_path('../..', __FILE__)
 
     def self.make(relative_project_root, config_file)

--- a/lib/thrust/ios/cedar.rb
+++ b/lib/thrust/ios/cedar.rb
@@ -8,31 +8,17 @@ module Thrust
         @out = out
       end
 
-      def run(build_configuration, target, runtime_sdk, build_sdk, device, device_type_id, build_dir, simulator_binary)
+      def run(build_configuration, target, build_sdk, os_version, device_name, build_dir, simulator_binary)
         if build_sdk == 'macosx'
           build_path = File.join(build_dir, build_configuration)
           app_dir = File.join(build_path, target)
           @thrust_executor.check_command_for_failure(app_dir.inspect, {'DYLD_FRAMEWORK_PATH' => build_path.inspect})
         else
+          device_type_id = "com.apple.CoreSimulator.SimDeviceType.#{device_name}, #{os_version}"
+
           app_executable = File.join(build_dir, "#{build_configuration}-#{build_sdk}", "#{target}.app")
-
-          if simulator_binary =~ /waxim%/
-            @thrust_executor.check_command_for_failure(%Q[#{simulator_binary} -s #{runtime_sdk} -f #{device} -e CFFIXED_USER_HOME=#{Dir.tmpdir} -e CEDAR_HEADLESS_SPECS=1 -e CEDAR_REPORTER_CLASS=CDRDefaultReporter #{app_executable}])
-          elsif simulator_binary =~ /ios-sim$/
-            if (device_type_id.nil?)
-              if device == "ipad"
-                @thrust_executor.check_command_for_failure(%Q[#{simulator_binary} launch #{app_executable} --sdk #{runtime_sdk} --family #{device} --setenv CFFIXED_USER_HOME=#{Dir.tmpdir} --setenv CEDAR_HEADLESS_SPECS=1 --setenv CEDAR_REPORTER_CLASS=CDRDefaultReporter])
-              else
-                @thrust_executor.check_command_for_failure(%Q[#{simulator_binary} launch #{app_executable} --sdk #{runtime_sdk} --family #{device} --retina --tall --setenv CFFIXED_USER_HOME=#{Dir.tmpdir} --setenv CEDAR_HEADLESS_SPECS=1 --setenv CEDAR_REPORTER_CLASS=CDRDefaultReporter])
-              end
-            else
-              @thrust_executor.check_command_for_failure(%Q[#{simulator_binary} launch #{app_executable} --devicetypeid '#{device_type_id}' --setenv CFFIXED_USER_HOME=#{Dir.tmpdir} --setenv CEDAR_HEADLESS_SPECS=1 --setenv CEDAR_REPORTER_CLASS=CDRDefaultReporter])
-            end
-
-          else
-            @out.puts "Unknown binary for running specs: '#{simulator_binary}'"
-            false
-          end
+          simulator_binary ||= 'ios-sim'
+          @thrust_executor.check_command_for_failure(%Q[#{simulator_binary} launch #{app_executable} --devicetypeid '#{device_type_id}' --setenv CFFIXED_USER_HOME=#{Dir.tmpdir} --setenv CEDAR_REPORTER_CLASS=CDRDefaultReporter])
         end
       end
     end

--- a/lib/thrust/ios/x_code_tools.rb
+++ b/lib/thrust/ios/x_code_tools.rb
@@ -39,8 +39,8 @@ module Thrust
         run_xcode(build_sdk, scheme_or_target, architecture)
       end
 
-      def test(scheme, build_configuration, runtime_sdk, build_dir)
-        destination = "OS=#{runtime_sdk},name=iPhone Retina (3.5-inch)"
+      def test(scheme, build_configuration, os_version, device_name, build_dir)
+        destination = "OS=#{os_version},name=#{device_name}"
 
         cmd = [
           "xcodebuild",
@@ -48,7 +48,6 @@ module Thrust
           "-scheme #{scheme}",
           "-configuration #{build_configuration}",
           "-destination '#{destination}'",
-          "ARCHS=i386",
           "SYMROOT='#{build_dir}'"
         ].join(' ')
 

--- a/lib/thrust/ios_spec_target.rb
+++ b/lib/thrust/ios_spec_target.rb
@@ -3,8 +3,8 @@ module Thrust
     attr_reader :build_configuration,
                 :build_sdk,
                 :device,
-                :device_type_id,
-                :runtime_sdk,
+                :device_name,
+                :os_version,
                 :scheme,
                 :target,
                 :type
@@ -13,8 +13,8 @@ module Thrust
       @build_configuration = attributes['build_configuration']
       @build_sdk = attributes['build_sdk'] || 'iphonesimulator'
       @device = attributes['device'] || 'iphone'
-      @device_type_id = attributes['device_type_id']
-      @runtime_sdk = attributes['runtime_sdk']
+      @device_name = attributes['device_name']
+      @os_version = attributes['os_version']
       @scheme = attributes['scheme']
       @target = attributes['target']
       @type = attributes['type'] || 'app'

--- a/lib/thrust/tasks/ios_specs.rb
+++ b/lib/thrust/tasks/ios_specs.rb
@@ -15,7 +15,7 @@ module Thrust
         target = target_info.target
         scheme = target_info.scheme
         build_sdk = target_info.build_sdk
-        runtime_sdk = args[:runtime_sdk] || target_info.runtime_sdk
+        os_version = args[:os_version] || target_info.os_version
 
         tools_options = {
           project_name: thrust.app_config.project_name,
@@ -27,9 +27,9 @@ module Thrust
 
         if type == 'app'
           xcode_tools.kill_simulator
-          @cedar.run(build_configuration, target, runtime_sdk, build_sdk, target_info.device, target_info.device_type_id, thrust.build_dir, thrust.app_config.ios_sim_binary)
+          @cedar.run(build_configuration, target, build_sdk, os_version, target_info.device_name, thrust.build_dir, thrust.app_config.ios_sim_path)
         else
-          xcode_tools.test(target || scheme, build_configuration, runtime_sdk, thrust.build_dir)
+          xcode_tools.test(target || scheme, build_configuration, os_version, target_info.device_name, thrust.build_dir)
         end
       end
     end

--- a/spec/lib/thrust/app_config_spec.rb
+++ b/spec/lib/thrust/app_config_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe Thrust::AppConfig do
   it 'exposes the ios sim binary' do
-    config = Thrust::AppConfig.new('ios_sim_binary' => 'ios-sim-binary')
-    expect(config.ios_sim_binary).to eq('ios-sim-binary')
+    config = Thrust::AppConfig.new('ios_sim_path' => 'ios-sim-binary')
+    expect(config.ios_sim_path).to eq('ios-sim-binary')
   end
 
   it 'exposes the ios_spec_targets when passed in' do

--- a/spec/lib/thrust/ios/x_code_tools_spec.rb
+++ b/spec/lib/thrust/ios/x_code_tools_spec.rb
@@ -47,7 +47,8 @@ describe Thrust::IOS::XCodeTools do
 
       thrust_executor.stub(:check_command_for_failure).and_return(command_result)
 
-      subject.test('scheme', 'build_configuration', 'runtime_sdk', 'build_dir').should == command_result
+      subject.test('scheme', 'build_configuration', 'os_version', 'device_name', 'build_dir').should == command_result
+      expect(thrust_executor).to have_received(:check_command_for_failure).with("xcodebuild test -scheme scheme -configuration build_configuration -destination 'OS=os_version,name=device_name' SYMROOT='build_dir'")
     end
   end
 

--- a/spec/lib/thrust/ios_spec_target_spec.rb
+++ b/spec/lib/thrust/ios_spec_target_spec.rb
@@ -26,19 +26,19 @@ describe Thrust::IOSSpecTarget do
     expect(target.device).to eq('some-device')
   end
 
-  it 'exposes the device type id' do
-    target = Thrust::IOSSpecTarget.new('device_type_id' => 'some-device-id')
-    expect(target.device_type_id).to eq('some-device-id')
+  it 'exposes the device name' do
+    target = Thrust::IOSSpecTarget.new('device_name' => 'some-device-name')
+    expect(target.device_name).to eq('some-device-name')
+  end
+
+  it 'exposes the os version' do
+    target = Thrust::IOSSpecTarget.new('os_version' => 'some-os-version')
+    expect(target.os_version).to eq('some-os-version')
   end
 
   it 'defaults the device type to iphone' do
     target = Thrust::IOSSpecTarget.new({})
     expect(target.device).to eq('iphone')
-  end
-
-  it 'exposes the runtime sdk' do
-    target = Thrust::IOSSpecTarget.new('runtime_sdk' => 'some-sdk')
-    expect(target.runtime_sdk).to eq('some-sdk')
   end
 
   it 'exposes the scheme name' do

--- a/spec/lib/thrust/tasks/ios_specs_spec.rb
+++ b/spec/lib/thrust/tasks/ios_specs_spec.rb
@@ -13,7 +13,7 @@ describe Thrust::Tasks::IOSSpecs do
         app_config = Thrust::AppConfig.new(
           'project_name' => 'project-name',
           'workspace_name' => 'workspace-name',
-          'ios_sim_binary' => 'ios-sim'
+          'ios_sim_path' => '/path/to/ios-sim'
         )
 
         thrust = double(Thrust::Config)
@@ -28,11 +28,11 @@ describe Thrust::Tasks::IOSSpecs do
         target_info = Thrust::IOSSpecTarget.new(
           'type' => 'app',
           'device' => 'device',
-          'device_type_id' => 'device-type-id',
+          'device_name' => 'device-name',
+          'os_version' => 'os-version',
           'target' => 'some-target',
           'scheme' => 'some-scheme',
           'build_sdk' => 'build-sdk',
-          'runtime_sdk' => 'runtime-sdk',
           'build_configuration' => 'build-configuration'
         )
 
@@ -44,7 +44,7 @@ describe Thrust::Tasks::IOSSpecs do
 
         expect(xcode_tools).to receive(:build_scheme_or_target).with('some-scheme', 'build-sdk')
         expect(xcode_tools).to receive(:kill_simulator)
-        expect(cedar).to receive(:run).with('build-configuration', 'some-target', 'runtime-sdk', 'build-sdk', 'device', 'device-type-id', 'build-dir', 'ios-sim').and_return(:success)
+        expect(cedar).to receive(:run).with('build-configuration', 'some-target', 'build-sdk', 'os-version','device-name', 'build-dir', '/path/to/ios-sim').and_return(:success)
 
         result = subject.run(thrust, target_info, args)
         expect(result).to eq(:success)
@@ -56,7 +56,7 @@ describe Thrust::Tasks::IOSSpecs do
         app_config = Thrust::AppConfig.new(
           'project_name' => 'project-name',
           'workspace_name' => 'workspace-name',
-          'ios_sim_binary' => 'ios-sim'
+          'ios_sim_path' => 'ios-sim'
         )
 
         thrust = double(Thrust::Config)
@@ -71,11 +71,11 @@ describe Thrust::Tasks::IOSSpecs do
         target_info = Thrust::IOSSpecTarget.new(
           'type' => 'bundle',
           'device' => 'device',
-          'device_type_id' => 'device-type-id',
+          'device_name' => 'device-name',
+          'os_version' => 'os-version',
           'target' => 'some-target',
           'scheme' => 'some-scheme',
           'build_sdk' => 'build-sdk',
-          'runtime_sdk' => 'runtime-sdk',
           'build_configuration' => 'build-configuration'
         )
 
@@ -86,7 +86,7 @@ describe Thrust::Tasks::IOSSpecs do
         xcode_tools_provider.stub(:instance).with(out, 'build-configuration', 'build-dir', tools_options).and_return(xcode_tools)
 
         expect(xcode_tools).to receive(:build_scheme_or_target).with('some-scheme', 'build-sdk')
-        expect(xcode_tools).to receive(:test).with('some-target', 'build-configuration', 'runtime-sdk', 'build-dir').and_return(:success)
+        expect(xcode_tools).to receive(:test).with('some-target', 'build-configuration', 'os-version', 'device-name', 'build-dir').and_return(:success)
 
         result = subject.run(thrust, target_info, args)
         expect(result).to eq(:success)

--- a/thrust.gemspec
+++ b/thrust.gemspec
@@ -2,8 +2,8 @@ require 'rake'
 
 Gem::Specification.new do |s|
   s.name        = 'thrust'
-  s.version     = '0.4.0'
-  s.date        = '2013-07-24'
+  s.version     = '0.5.0'
+  s.date        = '2014-11-05'
   s.summary     = 'Thrust is a collection of rake tasks for iOS/Android development and deployment'
   s.description = 'Thrust provides a collection of rake tasks for iOS and Android projects.  These include tasks for running Cedar test suites (iOS) and for deploying apps to Testflight (iOS and Android).'
   s.authors = [
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
     'Molly Trombley-McCann',
     'Philip Kuryloski',
     'Rachel Bobbins',
+    'Raphael Weiner',
     'Sheel Choksi',
     'Tyler Schultz',
     'Wiley Kestner'


### PR DESCRIPTION
Bumps version to 0.5
- Removes support for waxsim
- Unifies configuration of Cedar Spec Suites and Cedar/iOS/OSX test bundles in thrust.yml (breaking configuration changes)
- Fixes hardcoded bundle test destination which was broken in Xcode 6+
- Allows bundles to be built for architectures specified in Xcode project (removes hardcoded ARCHS flag)
- Adds support for specifying an alternate path to ios-sim
