### PR TITLE
git should not be set back to master if that was not the branch checked out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Thrust Changelog
 
+## Unreleased Changes
+
+* The `build_ipa` rake task will no longer invoke `git checkout master` but will instead checkout the last branch you were on before you invoked thrust.
+
 ## Version 0.7.1 Changes
 
 * Adds option to specify a scheme to build (instead of a target) for deployment.

--- a/lib/thrust/git.rb
+++ b/lib/thrust/git.rb
@@ -28,7 +28,7 @@ module Thrust
 
     def reset
       @thrust_executor.system_or_exit('git reset --hard')
-      @thrust_executor.system_or_exit('git checkout master')
+      @thrust_executor.system_or_exit('git checkout @{-1}')
     end
 
     def checkout_file(filename)

--- a/lib/thrust/ipa_builder.rb
+++ b/lib/thrust/ipa_builder.rb
@@ -36,8 +36,6 @@ module Thrust
           ipa_file = @xcode_tools.cleanly_create_ipa_with_target(target, app_name, @app_config.distribution_certificate, @deployment_config.provisioning_search_query)
         end
 
-        @git.reset
-
         @out.puts "\n\n"
         @out.puts "Successfully built .ipa:".green
         @out.puts ipa_file
@@ -46,8 +44,9 @@ module Thrust
         @out.puts e.message.red
         @out.puts "\n\n"
 
-        @git.reset
         exit 1
+      ensure
+        @git.reset
       end
     end
   end

--- a/spec/lib/thrust/git_spec.rb
+++ b/spec/lib/thrust/git_spec.rb
@@ -28,6 +28,15 @@ describe Thrust::Git do
     end
   end
 
+  describe '#reset' do
+    it 'resets the working directory back to its original state' do
+      expect(thrust_executor).to receive(:system_or_exit).with('git reset --hard').once
+      expect(thrust_executor).to receive(:system_or_exit).with('git checkout @{-1}').once
+
+      subject.reset
+    end
+  end
+
   describe '#checkout_tag' do
     it 'should checkout the latest commit that has the tag' do
       expect(thrust_executor).to receive(:capture_output_from_system).with('autotag list ci').and_return("7342334 ref/blah\nlatest_ci_tag ref/blahblah")

--- a/spec/lib/thrust/ipa_builder_spec.rb
+++ b/spec/lib/thrust/ipa_builder_spec.rb
@@ -63,7 +63,7 @@ describe Thrust::IPABuilder do
       end
 
       it 'should reset the working directory' do
-        expect(git).to receive(:reset)
+        expect(git).to receive(:reset).once
         begin
           deploy.run
         rescue SystemExit
@@ -76,7 +76,7 @@ describe Thrust::IPABuilder do
     end
 
     it 'resets the changes after the deploy' do
-      expect(git).to receive(:reset)
+      expect(git).to receive(:reset).once
       deploy.run
     end
 


### PR DESCRIPTION
I was using thrust recently while working on a feature branch and found that every time I invoked `rake build_ipa:my_scheme_name` that git was returned to the master branch. Sure enough, I poked around in the source code and thrust invoked `git checkout master`. This is unfortunate, because sometimes people want to be able to use thrust from a feature branch.

Git allows users to check out the n-th last branch or commit they had checked out, with the command `git checkout @{-n}`. This can be shortened to `git checkout -`, but I didn't think that was readable enough. 

This seemed like a reasonable enough change, but I thought it would be worth opening a pull request just to get some eyes on it first.