### PR TITLE
allow for building apps with different names in the same workspace

### DIFF
--- a/lib/thrust/deployment_target.rb
+++ b/lib/thrust/deployment_target.rb
@@ -8,7 +8,8 @@ module Thrust
                 :note_generation_method,
                 :notify,
                 :versioning_method,
-                :tag
+                :tag,
+                :app_name
 
     def initialize(attributes)
       @distribution_list = attributes['distribution_list']
@@ -20,6 +21,7 @@ module Thrust
       @notify = attributes['notify']
       @versioning_method = attributes['versioning_method']
       @tag = attributes['tag']
+      @app_name = attributes['app_name']
     end
   end
 end

--- a/lib/thrust/ipa_builder.rb
+++ b/lib/thrust/ipa_builder.rb
@@ -27,6 +27,9 @@ module Thrust
         end
 
         app_name = @app_config.app_name
+        if @deployment_config.app_name
+          app_name = @deployment_config.app_name
+        end
         target = @deployment_config.target || app_name
         scheme = @deployment_config.scheme
 

--- a/spec/lib/thrust/ipa_builder_spec.rb
+++ b/spec/lib/thrust/ipa_builder_spec.rb
@@ -220,5 +220,22 @@ describe Thrust::IPABuilder do
         deploy.run
       end
     end
+
+    context 'when the app_name is specified in deployment target' do
+      let(:distribution_config) do
+        Thrust::DeploymentTarget.new(
+            'app_name' => 'target_app_name',
+            'notify' => 'true',
+            'distribution_list' => 'devs',
+            'build_configuration' => 'configuration',
+            'provisioning_search_query' => 'Provisioning Profile query'
+        )
+      end
+
+      it 'creates the ipa, using the app_name from the deployment target' do
+        expect(xcode_tools).to receive(:cleanly_create_ipa_with_target).with('target_app_name', 'target_app_name', 'signing_identity', 'Provisioning Profile query')
+        deploy.run
+      end
+    end
   end
 end


### PR DESCRIPTION
This is useful when you have more then one build target generating .ipa files with different names.
eg. different branding, frameworks, etc...
